### PR TITLE
Fix codemirror field for draft entries

### DIFF
--- a/src/fields/CodeMirrorField.php
+++ b/src/fields/CodeMirrorField.php
@@ -170,8 +170,16 @@ class CodeMirrorField extends Field
 		}
 
 		$options = Json::encode($options);
-		$view->registerJs("CodeMirror.fromTextArea($('#$namespacedId')[0], $options);");
-
+				
+		$view->registerJs("
+			(function() {
+				var editor = CodeMirror.fromTextArea($('#$namespacedId')[0], $options);
+				editor.on('change', function() {
+					editor.save();
+				});
+			})();
+		");
+		
 		// Render the input template
 		return $view->renderTemplate(
 			'code-mirror'


### PR DESCRIPTION
This fixes the issue where codemirror field data would not get saved on new/draft entries in Craft 3.2+. The issue stems from how Craft now handles draft forms. [It generates an entirely new form](https://github.com/craftcms/cms/blob/807e4916e1fcc35ecbdd7532f0335cb61ef2a7f8/src/web/assets/cp/src/js/DraftEditor.js#L668) and submits that, which breaks codemirror's internal submit handler. That handler is supposed to copy the data out to the original textarea, but it never fires.

The fix works around this by listening to codemirror's `change` event and copying data out as it is entered.

Thanks.