### PR TITLE
Craft 4 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,5 +34,10 @@
         "handle": "code-mirror",
         "changelogUrl": "https://raw.githubusercontent.com/luwes/craft3-codemirror/master/CHANGELOG.md",
         "class": "luwes\\codemirror\\CodeMirror"
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "require-dev": {
+        "craftcms/rector": "dev-main"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         }
     ],
     "require": {
-        "craftcms/cms": "^3.0.0-beta.20"
+        "php": "^8.0",
+        "craftcms/cms": "^3.0.0-beta.20 || ^4.0.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/CodeMirror.php
+++ b/src/CodeMirror.php
@@ -71,7 +71,7 @@ class CodeMirror extends Plugin
 	// Protected Methods
 	// =========================================================================
 
-	protected function createSettingsModel()
+	protected function createSettingsModel(): ?\craft\base\Model
 	{
 		return new Settings();
 	}

--- a/src/fields/CodeMirrorField.php
+++ b/src/fields/CodeMirrorField.php
@@ -51,7 +51,7 @@ class CodeMirrorField extends Field
 	/**
 	 * @inheritdoc
 	 */
-	public function rules()
+	public function rules(): array
 	{
 		$rules = parent::rules();
 		$rules = array_merge($rules, [
@@ -63,7 +63,7 @@ class CodeMirrorField extends Field
 	/**
 	 * @inheritdoc
 	 */
-	public function getContentColumnType(): string
+	public function getContentColumnType(): array|string
 	{
 		return Schema::TYPE_TEXT;
 	}
@@ -71,7 +71,7 @@ class CodeMirrorField extends Field
 	/**
 	 * @inheritdoc
 	 */
-	public function normalizeValue($value, ElementInterface $element = null)
+	public function normalizeValue(mixed $value, ?\craft\base\ElementInterface $element = null): mixed
 	{
 		return $value;
 	}
@@ -79,7 +79,7 @@ class CodeMirrorField extends Field
 	/**
 	 * @inheritdoc
 	 */
-	public function serializeValue($value, ElementInterface $element = null)
+	public function serializeValue(mixed $value, ?\craft\base\ElementInterface $element = null): mixed
 	{
 		return parent::serializeValue($value, $element);
 	}
@@ -87,7 +87,7 @@ class CodeMirrorField extends Field
 	/**
 	 * @inheritdoc
 	 */
-	public function getSettingsHtml()
+	public function getSettingsHtml(): ?string
 	{
 		$settings = CodeMirror::getInstance()->getSettings();
 		$modes = [];
@@ -114,7 +114,7 @@ class CodeMirrorField extends Field
 	/**
 	 * @inheritdoc
 	 */
-	public function getInputHtml($value, ElementInterface $element = null): string
+	public function getInputHtml(mixed $value, ?\craft\base\ElementInterface $element = null): string
 	{
 		$am = Craft::$app->getAssetManager();
 		$view = Craft::$app->getView();


### PR DESCRIPTION
This PR just adds the minor changes required for Craft 4 support. The changes also requires PHP 8, consistent with the syntax changes required and Craft 4's minimum requirements.

I'd probably also suggest renaming the repo to craft-codemirror from craft3-codemirror, as I don't think a separate fork is required for Craft 4 support, and it'd only make sense to maintain separate branches if you want to continue to support a version that doesn't require PHP 8.